### PR TITLE
Fix to validate field declaration of config, replace rangeKey with sortKey.

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -8,8 +8,8 @@ tables:
       lastSeen: 'integer'
     expireKey: 'expiresAt'
     hashKey: 'channelId'
-    rangeKey: 'id'
+    sortKey: 'id'
     subIndices:
       guest:
         hashKey: 'channelId'
-        rangeKey: 'lastSeen'
+        sortKey: 'lastSeen'

--- a/config/test_config.yml
+++ b/config/test_config.yml
@@ -8,8 +8,8 @@ tables:
       lastSeen: 'integer'
     expireKey: 'expiresAt'
     hashKey: 'channelId'
-    rangeKey: 'id'
+    sortKey: 'id'
     subIndices:
       guest:
         hashKey: 'channelId'
-        rangeKey: 'lastSeen'
+        sortKey: 'lastSeen'

--- a/model/bingo.go
+++ b/model/bingo.go
@@ -2,9 +2,6 @@ package model
 
 import (
 	"fmt"
-	"github.com/zoyi/bingodb/ds/redblacktree"
-	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -15,89 +12,21 @@ type Bingo struct {
 	Keeper *Keeper
 }
 
-type tableInfo struct {
-	Fields     map[string]string    `yaml:"fields"`
-	HashKey    string               `yaml:"hashKey"`
-	RangeKey   string               `yaml:"rangeKey"`
-	SubIndices map[string]indexInfo `yaml:"subIndices"`
-	ExpireKey  string               `yaml:"expireKey"`
-}
-
-type indexInfo struct {
-	HashKey  string `yaml:"hashKey"`
-	RangeKey string `yaml:"rangeKey"`
-}
-
-type configInfo struct {
-	Tables map[string]tableInfo `yaml:"tables"`
-}
-
 func Load(filename string) *Bingo {
 	projectPath := filepath.Join(os.Getenv("GOPATH"), "/src/github.com/zoyi/bingodb/")
 	absPath, _ := filepath.Abs(filepath.Join(projectPath, "/config", filename))
-	source, err := ioutil.ReadFile(absPath)
+
+	bingo := newBingo()
+	err := ParseConfig(bingo, absPath)
 	if err != nil {
 		fmt.Println(err)
 		log.Fatalf("error: %v", err)
 	}
-
-	configInfo := configInfo{}
-
-	err = yaml.Unmarshal(source, &configInfo)
-
-	if err != nil {
-		fmt.Println(err)
-		log.Fatalf("error: %v", err)
-	}
-
-	return parse(&configInfo)
+	return bingo
 }
 
 func newBingo() *Bingo {
 	return &Bingo{Tables: make(map[string]*Table), Keeper: newKeeper()}
-}
-
-func parse(configInfo *configInfo) *Bingo {
-	config := newBingo()
-
-	for tableName, tableInfo := range configInfo.Tables {
-		fields := make(map[string]*FieldSchema)
-		for fieldKey, fieldType := range tableInfo.Fields {
-			field := &FieldSchema{Name: fieldKey, Type: fieldType}
-			fields[fieldKey] = field
-		}
-
-		primaryKey := &Key{
-			HashKey: fields[tableInfo.HashKey],
-			SortKey: fields[tableInfo.RangeKey]}
-
-		schema := &TableSchema{
-			Fields:       fields,
-			PrimaryKey:   primaryKey,
-			SubIndexKeys: make(map[string]*Key),
-			ExpireField:  fields[tableInfo.ExpireKey]}
-
-		primaryIndex := &PrimaryIndex{&Index{
-			Data: make(map[interface{}]*redblacktree.Tree),
-			Key:  primaryKey}}
-
-		subIndices := make(map[string]*SubIndex)
-		for indexName, indexInfo := range tableInfo.SubIndices {
-			subKey := &Key{HashKey: fields[indexInfo.HashKey],
-				SortKey: fields[indexInfo.RangeKey]}
-
-			schema.SubIndexKeys[indexName] = subKey
-
-			subIndices[indexName] = &SubIndex{&Index{
-				Data: make(map[interface{}]*redblacktree.Tree),
-				Key:  subKey}}
-		}
-
-		config.AddTable(tableName, schema, primaryIndex, subIndices)
-
-	}
-
-	return config
 }
 
 func (bingo *Bingo) AddTable(

--- a/model/config.go
+++ b/model/config.go
@@ -1,0 +1,127 @@
+package model
+
+import (
+	"github.com/zoyi/bingodb/ds/redblacktree"
+	"io/ioutil"
+	"gopkg.in/yaml.v2"
+	"errors"
+	"reflect"
+	"fmt"
+)
+
+type TableInfo struct {
+	Fields     map[string]string    `yaml:"fields"`
+	HashKey    string               `yaml:"hashKey"`
+	SortKey    string               `yaml:"sortKey"`
+	SubIndices map[string]IndexInfo `yaml:"subIndices"`
+	ExpireKey  string               `yaml:"expireKey"`
+}
+
+type IndexInfo struct {
+	HashKey string `yaml:"hashKey"`
+	SortKey string `yaml:"sortKey"`
+}
+
+type ConfigInfo struct {
+	Tables map[string]TableInfo `yaml:"tables"`
+}
+
+
+// Load configuration file with specified path and
+// parse it to create table schema to prepare Bingo.
+// It returns any error encountered.
+func ParseConfig(bingo *Bingo, path string) error {
+	configBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return ParseConfigBytes(bingo, configBytes)
+}
+
+// Parse specified string of configuration and
+// create table schema to prepare Bingo.
+// It returns any error encountered.
+func ParseConfigString(bingo *Bingo, configString string) error {
+	return ParseConfigBytes(bingo, []byte(configString))
+}
+
+// Parse specified bytes of configuration and
+// create table schema to prepare Bingo.
+// It returns any error encountered.
+func ParseConfigBytes(bingo *Bingo, config []byte) error {
+	configInfo := &ConfigInfo{}
+
+	if err := yaml.Unmarshal(config, configInfo); err != nil {
+		return err
+	}
+
+	for tableName, tableInfo := range configInfo.Tables {
+		fields := make(map[string]*FieldSchema)
+
+		// Validate declared fields
+		t := reflect.TypeOf(tableInfo)
+		v := reflect.ValueOf(tableInfo)
+
+		for i := 0; i < t.NumField(); i++ {
+			sf := t.Field(i)
+
+			switch sf.Name {
+			case "Fields": continue
+			case "SubIndices":
+				for _, indexInfo := range tableInfo.SubIndices {
+					iit := reflect.TypeOf(indexInfo)
+					iiv := reflect.ValueOf(indexInfo)
+					for s := 0; s < iit.NumField(); s++ {
+						ssf := iit.Field(s)
+						sfv := iiv.Field(s).String()
+						if _, ok := tableInfo.Fields[sfv]; !ok {
+							return errors.New(
+								fmt.Sprintf("Table configuration error - undefined field '%v' for SubIndices '%v'", sfv, ssf.Name))
+						}
+					}
+				}
+			default:
+				fv := v.Field(i).String()
+				if _, ok := tableInfo.Fields[fv]; !ok {
+					return errors.New(
+						fmt.Sprintf("Table configuration error - undefined field '%v' for '%v'", fv, sf.Name))
+				}
+			}
+		}
+
+		for fieldKey, fieldType := range tableInfo.Fields {
+			field := &FieldSchema{Name: fieldKey, Type: fieldType}
+			fields[fieldKey] = field
+		}
+
+		primaryKey := &Key{
+			HashKey: fields[tableInfo.HashKey],
+			SortKey: fields[tableInfo.SortKey]}
+
+		schema := &TableSchema{
+			Fields:       fields,
+			PrimaryKey:   primaryKey,
+			SubIndexKeys: make(map[string]*Key),
+			ExpireField:  fields[tableInfo.ExpireKey]}
+
+		primaryIndex := &PrimaryIndex{&Index{
+			Data: make(map[interface{}]*redblacktree.Tree),
+			Key:  primaryKey}}
+
+		subIndices := make(map[string]*SubIndex)
+		for indexName, indexInfo := range tableInfo.SubIndices {
+			subKey := &Key{HashKey: fields[indexInfo.HashKey],
+				SortKey: fields[indexInfo.SortKey]}
+
+			schema.SubIndexKeys[indexName] = subKey
+
+			subIndices[indexName] = &SubIndex{&Index{
+				Data: make(map[interface{}]*redblacktree.Tree),
+				Key:  subKey}}
+		}
+
+		bingo.AddTable(tableName, schema, primaryIndex, subIndices)
+	}
+
+	return nil
+}

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -1,0 +1,174 @@
+package model
+
+import (
+	"testing"
+	"path/filepath"
+	"os"
+	"fmt"
+)
+
+var (
+	projectPath = filepath.Join(os.Getenv("GOPATH"), "/src/github.com/zoyi/bingodb/")
+)
+
+func TestParseConfig(t *testing.T) {
+	bingo := newBingo()
+	absPath, _ := filepath.Abs(filepath.Join(projectPath, "/config", "test_config.yml"))
+
+	if err := ParseConfig(bingo, absPath); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestParseConfigString(t *testing.T) {
+	configString := `
+tables:
+  weired:
+    fields:
+      id: 'string'
+      name: 'string'
+      email: 'string'
+      expiresAt: 'integer'
+    expireKey: 'expiresAt'
+    hashKey: 'name'
+    sortKey: 'id'
+    subIndices:
+      friends:
+        hashKey: 'email'
+        sortKey: 'name'
+`
+
+	bingo := newBingo()
+
+	if err := ParseConfigString(bingo, configString); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestErrorWhenUndefinedField(t *testing.T) {
+	// tables > weired > expireKey is invalid
+	weiredFieldConfig1 := `
+tables:
+  weired:
+    fields:
+      id: 'string'
+      name: 'string'
+      email: 'string'
+      expiresAt: 'integer'
+    expireKey: 'weired'
+    hashKey: 'name'
+    sortKey: 'id'
+    subIndices:
+      friends:
+        hashKey: 'email'
+        sortKey: 'name'
+`
+
+	bingo := newBingo()
+
+	if err := ParseConfigString(bingo, weiredFieldConfig1); err != nil {
+		fmt.Printf("Error occurred: [%v] - ok \n", err)
+	} else {
+		t.Fail()
+	}
+
+	// tables > weired > hashKey is invalid
+	weiredFieldConfig2 := `
+tables:
+  weired:
+    fields:
+      id: 'string'
+      name: 'string'
+      email: 'string'
+      expiresAt: 'integer'
+    expireKey: 'expiresAt'
+    hashKey: 'weired'
+    sortKey: 'id'
+    subIndices:
+      friends:
+        hashKey: 'email'
+        sortKey: 'name'
+`
+
+	if err := ParseConfigString(bingo, weiredFieldConfig2); err != nil {
+		fmt.Printf("Error occurred: [%v] - ok \n", err)
+	} else {
+		t.Fail()
+	}
+
+	// tables > weired > sortKey is invalid
+	weiredFieldConfig3 := `
+tables:
+  weired:
+    fields:
+      id: 'string'
+      name: 'string'
+      email: 'string'
+      expiresAt: 'integer'
+    expireKey: 'expiresAt'
+    hashKey: 'name'
+    sortKey: 'weired'
+    subIndices:
+      friends:
+        hashKey: 'email'
+        sortKey: 'name'
+`
+
+	if err := ParseConfigString(bingo, weiredFieldConfig3); err != nil {
+		fmt.Printf("Error occurred: [%v] - ok \n", err)
+	} else {
+		t.Fail()
+	}
+}
+
+func TestErrorWhenUndefinedFieldOfSubIndices(t *testing.T) {
+	// tables >> weired >> subIndices >> friends >> hashKey is invalid
+	weiredSubIndicesConfig1 := `
+tables:
+  weired:
+    fields:
+      id: 'string'
+      name: 'string'
+      email: 'string'
+      expiresAt: 'integer'
+    expireKey: 'expiresAt'
+    hashKey: 'email'
+    sortKey: 'id'
+    subIndices:
+      friends:
+        hashKey: 'weired'
+        sortKey: 'name'
+`
+
+	bingo := newBingo()
+
+	if err := ParseConfigString(bingo, weiredSubIndicesConfig1); err != nil {
+		fmt.Printf("Error occurred: [%v] - ok \n", err)
+	} else {
+		t.Fail()
+	}
+
+	// tables >> weired >> subIndices >> friends >> sortKey is invalid
+	weiredSubIndicesConfig2 := `
+tables:
+  weired:
+    fields:
+      id: 'string'
+      name: 'string'
+      email: 'string'
+      expiresAt: 'integer'
+    expireKey: 'expiresAt'
+    hashKey: 'email'
+    sortKey: 'id'
+    subIndices:
+      friends:
+        hashKey: 'email'
+        sortKey: 'weired'
+`
+
+	if err := ParseConfigString(bingo, weiredSubIndicesConfig2); err != nil {
+		fmt.Printf("Error occurred: [%v] - ok \n", err)
+	} else {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Issue - #10 

* Replace all `rangeKey` with `sortKey` as well as corresponding struct fields.
* Split codes for parse configuration to new `config.go` file.
* Add validating field declaration of configuration.
  - `ParseConfig()` function returns error when some key refers field which is not declared in `field` of config.
* Add corresponding test cases into `config_test.go` file.